### PR TITLE
Normalize bullet indents/tabs based on font size

### DIFF
--- a/NSAttributedString+Markdown.m
+++ b/NSAttributedString+Markdown.m
@@ -175,7 +175,7 @@ NSString *const bulletLevelGreaterThan2 = @"∙";
 
 NSString *const bulletFontName = @"HelveticaNeue-Medium";
 
-CGFloat const bulletIndentWidth = 20.0;
+CGFloat const standardBulletIndentWidth = 20.0;
 #endif
 
 #if ALLOW_UNDERLINE
@@ -623,6 +623,7 @@ static void updateAttributedString(NSMutableAttributedString *result, NSString *
                             
                             NSRange listItemRangeWithBullet = NSMakeRange(mutatedBeginRange.location, endRange.location - mutatedBeginRange.location + endRange.length - mutationOffset - 1);
                             NSMutableParagraphStyle *paragraphStyle = [[result attribute:NSParagraphStyleAttributeName atIndex:listItemRangeWithBullet.location effectiveRange:NULL] mutableCopy] ?: [[NSParagraphStyle defaultParagraphStyle] mutableCopy];
+                            CGFloat bulletIndentWidth = standardBulletIndentWidth * baseFont.pointSize / 17;
                             CGFloat bulletIndent = bulletIndentWidth * bulletLevel;
                             CGFloat bulletedTextIndent = bulletIndentWidth * (bulletLevel + 1);
                             NSTextTab *firstTabStop = [[NSTextTab alloc] initWithTextAlignment:NSTextAlignmentLeft location:bulletedTextIndent options:@{}];


### PR DESCRIPTION
Fixes https://github.com/CareEvolution/CEVResearchKit/issues/254.

DynamicTextSize|BEFORE|AFTER|
|---|---|---|
|![smallest](https://user-images.githubusercontent.com/1008462/120863073-9a7e7880-c54f-11eb-9595-dff78f457ec5.jpg)|![small-after](https://user-images.githubusercontent.com/1008462/120863551-5cce1f80-c550-11eb-8127-090c84fd5240.png)|![After-smallest](https://user-images.githubusercontent.com/1008462/120863152-b41fc000-c54f-11eb-9a44-bcb70fa10f7f.png)|
|![middle](https://user-images.githubusercontent.com/1008462/120863085-9f432c80-c54f-11eb-8fb2-ceabbc18750f.jpg)|![merium-after](https://user-images.githubusercontent.com/1008462/120863578-6788b480-c550-11eb-862c-e92f77e6ebd4.png)|![After-middle](https://user-images.githubusercontent.com/1008462/120863193-c1d54580-c54f-11eb-951e-72ecf8b8c232.png)|
|![largest](https://user-images.githubusercontent.com/1008462/120863112-a5d1a400-c54f-11eb-80b1-27be6c900e09.jpg)|![Simulator Screen Shot - iPhone 12 - 2021-06-04 at 16 17 11](https://user-images.githubusercontent.com/1008462/120863610-70798600-c550-11eb-93e6-f562167e061b.png)|![After-largest](https://user-images.githubusercontent.com/1008462/120863225-cef23480-c54f-11eb-840c-4d64f7ee2416.png)|


